### PR TITLE
mac fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ cd ai-smcg-environment
 From Git Bash or the terminal, navigate to the root directory of the cloned repository and run the following command to start the Docker container using Docker Compose:
 
 ```sh
-docker-compose up --build
+docker compose up --build
 ```
 
 ### 3. Open in VSCode

--- a/environment.yml
+++ b/environment.yml
@@ -3,8 +3,9 @@ channels:
   - conda-forge
   - defaults
   - pytorch # PyTorch channel
+  - sfe1ed40
 dependencies:
-  - python=3.12
+  - python
   - langchain
   - pytorch
   - torchvision


### PR DESCRIPTION
we can't have python 3.12 as the channel which fixes the torchaudio for mac platform is using the latest version of python